### PR TITLE
Improve error handling during sign-up profile creation

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -111,11 +111,16 @@ export function AuthProvider({ children }) {
 
     const userId = newUser?.id;
     if (userId) {
-      await supabase.from('profiles').insert({
+      const { error: insertError } = await supabase.from('profiles').insert({
         id: userId,
         username,
         display_name: username,
       });
+
+      if (insertError) {
+        console.error('❌ Profile insert error:', insertError);
+        return { error: insertError };
+      }
 
       // Immediately store the authenticated user and profile
       setUser(newUser);
@@ -125,9 +130,12 @@ export function AuthProvider({ children }) {
         display_name: username,
         email: newUser.email,
       });
+
+      return { error: null };
     }
 
-    return { error: null };
+    // No userId should rarely happen, but surface an error if it does
+    return { error: { message: 'User ID missing after sign up' } };
   };
 
 


### PR DESCRIPTION
## Summary
- capture errors when inserting a profile after sign-up
- surface the insert error instead of setting the profile state

## Testing
- `npm test` *(fails: Missing script)*