### PR TITLE
Add Supabase profile insert policy

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -13,18 +13,27 @@ export function AuthProvider({ children }) {
   const ensureProfile = async (authUser) => {
     if (!authUser) return null;
 
+    // Try to load an existing profile first
     const existing = await fetchProfile(authUser.id);
     if (existing) return existing;
 
-    const defaultUsername = authUser.email
+    // Fall back to metadata or the email prefix if no profile exists
+    const metaUsername = authUser.user_metadata?.username;
+    const defaultUsername = metaUsername
+      ? metaUsername
+      : authUser.email
       ? authUser.email.split('@')[0]
       : 'anonymous';
 
-    await supabase.from('profiles').insert({
+    // Create a new profile with the provided or derived username
+    const { error } = await supabase.from('profiles').insert({
       id: authUser.id,
       username: defaultUsername,
       display_name: defaultUsername,
     });
+
+    // Log any insertion error for easier debugging
+    if (error) console.error('Failed to insert profile:', error);
 
     const profileData = {
       id: authUser.id,
@@ -111,11 +120,16 @@ export function AuthProvider({ children }) {
 
     const userId = newUser?.id;
     if (userId) {
-      await supabase.from('profiles').insert({
+      const { error: insertError } = await supabase.from('profiles').insert({
         id: userId,
         username,
         display_name: username,
       });
+
+      if (insertError) {
+        // The insert can fail if policies aren't set up yet
+        console.error('Failed to insert profile on sign up:', insertError);
+      }
 
       // Immediately store the authenticated user and profile
       setUser(newUser);
@@ -147,9 +161,15 @@ export function AuthProvider({ children }) {
       .single();
 
     if (!error && data) {
-      // Merge the Supabase auth email so other screens can rely on it
       const authUser = supabase.auth.user();
-      const profileData = { ...data, email: authUser?.email };
+      const meta = authUser?.user_metadata || {};
+      const profileData = {
+        ...data,
+        email: authUser?.email,
+        username: data.username || meta.username || authUser?.email?.split('@')[0],
+        display_name:
+          data.display_name || meta.display_name || data.username || meta.username,
+      };
       setProfile(profileData);
       return profileData;
     }

--- a/PoliticalHub/README.md
+++ b/PoliticalHub/README.md
@@ -17,3 +17,11 @@ Currently the app only displays a simple "Hello World" message. It is intended a
    Then scan the QR code with the Expo Go app on your iPhone.
 
 Remember to replace the Supabase credentials in `src/supabase.js` with your project credentials.
+
+## Supabase SQL scripts
+
+Run the SQL files found in the `sql/` directory using the Supabase dashboard.
+
+1. Open your project in Supabase and go to the **SQL editor**.
+2. Create a new query and paste in the contents of `sql/setup.sql` followed by `sql/profiles.sql`.
+3. Execute the query to set up the tables and policies. The second file creates an insert policy so that usernames saved during sign up persist on later logins.

--- a/sql/profiles.sql
+++ b/sql/profiles.sql
@@ -1,0 +1,5 @@
+-- Policy to allow users to create their own profile
+create policy "Users can insert their own profile"
+  on public.profiles for insert
+  with check (auth.uid() = id);
+


### PR DESCRIPTION
## Summary
- add SQL policy file to allow users to insert their own profile
- document running SQL setup scripts via Supabase
- ensure usernames persist across logins by creating profiles from metadata

## Testing
- `npm test` *(fails: Missing script)*