### PR TITLE
Persist username across logins

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -16,20 +16,23 @@ export function AuthProvider({ children }) {
     const existing = await fetchProfile(authUser.id);
     if (existing) return existing;
 
-    const defaultUsername = authUser.email
-      ? authUser.email.split('@')[0]
-      : 'anonymous';
+    const defaultUsername =
+      authUser.user_metadata?.username ||
+      (authUser.email ? authUser.email.split('@')[0] : 'anonymous');
+    const defaultDisplayName =
+      authUser.user_metadata?.display_name ||
+      defaultUsername;
 
     await supabase.from('profiles').insert({
       id: authUser.id,
       username: defaultUsername,
-      display_name: defaultUsername,
+      display_name: defaultDisplayName,
     });
 
     const profileData = {
       id: authUser.id,
       username: defaultUsername,
-      display_name: defaultUsername,
+      display_name: defaultDisplayName,
       email: authUser.email,
     };
 

--- a/PoliticalHub/README.md
+++ b/PoliticalHub/README.md
@@ -17,3 +17,11 @@ Currently the app only displays a simple "Hello World" message. It is intended a
    Then scan the QR code with the Expo Go app on your iPhone.
 
 Remember to replace the Supabase credentials in `src/supabase.js` with your project credentials.
+
+## Supabase SQL scripts
+
+Run the SQL files found in the `sql/` directory using the Supabase dashboard.
+
+1. Open your project in Supabase and go to the **SQL editor**.
+2. Create a new query and paste in the contents of `sql/setup.sql` and `sql/profiles.sql`.
+3. Execute the query to set up the tables and policies.

--- a/sql/profiles.sql
+++ b/sql/profiles.sql
@@ -1,0 +1,5 @@
+-- Policy to allow users to create their own profile
+create policy "Users can insert their own profile"
+  on public.profiles for insert
+  with check (auth.uid() = id);
+


### PR DESCRIPTION
## Summary
- pull username and display name from auth metadata when ensuring a profile
- keep sign-up username linked to future sessions

## Testing
- `npm test` *(fails: Missing script)*